### PR TITLE
Consistent optional behavior for X.509 certificate thumbprints

### DIFF
--- a/jwk.go
+++ b/jwk.go
@@ -301,6 +301,13 @@ func (j JWK) Validate() error {
 		return fmt.Errorf("failed to marshal JSON Web Key: %w", errors.Join(ErrJWKValidation, err))
 	}
 
+	if j.marshal.X5T == "" {
+		marshalled.X5T = ""
+	}
+	if j.marshal.X5TS256 == "" {
+		marshalled.X5TS256 = ""
+	}
+
 	ok := reflect.DeepEqual(j.marshal, marshalled)
 	if !ok {
 		return fmt.Errorf("%w: marshaled JWK does not match original JWK", ErrJWKValidation)


### PR DESCRIPTION
This package automatically calculates X.509 certificate thumbprints. This behavior was not accounted for in the existing `JWK.Validate` implementation, causing inconsistent behavior with `NewJWKFromMarshal` when the inputted `JWKMarshal` JWK Set did not contain these optional parameters.

This pull request changes the `JWK.Validate` behavior to ignore comparing the `x5t` and `x5t#S256` parameters when they are not present in the original.

See https://github.com/MicahParks/jwkset/issues/11 for the relevant issue.