### PR TITLE
Unknown kid refresh

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/MicahParks/jwkset
 
 go 1.21.5
+
+require golang.org/x/time v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/time v0.5.0 h1:o7cqy6amK/52YcAKIPlM3a+Fpj35zvRj2TP+e1xFSfk=
+golang.org/x/time v0.5.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=

--- a/http.go
+++ b/http.go
@@ -72,6 +72,12 @@ func NewHTTPClient(options HTTPClientOptions) (Storage, error) {
 }
 
 // NewDefaultHTTPClient creates a new JWK Set client with default options from remote HTTP resources.
+//
+// The default behavior is to:
+// 1. Refresh remote HTTP resources every hour.
+// 2. Prioritize keys from remote HTTP resources over keys from the given storage.
+// 3. Refresh remote HTTP resources if a key with an unknown key ID is trying to be read, with a rate limit of 5 minutes.
+// 4. Log to slog.Default() if a refresh fails.
 func NewDefaultHTTPClient(urls []string) (Storage, error) {
 	clientOptions := HTTPClientOptions{
 		HTTPURLs:          make(map[string]Storage),

--- a/http.go
+++ b/http.go
@@ -8,6 +8,8 @@ import (
 	"log/slog"
 	"net/url"
 	"time"
+
+	"golang.org/x/time/rate"
 )
 
 var (
@@ -25,13 +27,22 @@ type HTTPClientOptions struct {
 	// PrioritizeHTTP is a flag that indicates whether keys from the HTTP URL should be prioritized over keys from the
 	// given storage.
 	PrioritizeHTTP bool
+	// RefreshUnknownKID is a flag that indicates that remote HTTP resources should be refreshed if an unknown KID is
+	// found. This will block until the context is canceled, an error occurs, the KID is found, or all refreshes have
+	// been performed
+	RefreshUnknownKID bool
+	// RefreshLimiter is a rate limiter for refreshing remote HTTP resources. This is required if RefreshUnknownKID is
+	// set to true.
+	RefreshLimiter *rate.Limiter
 }
 
 // Client is a JWK Set client.
 type httpClient struct {
-	given          Storage
-	httpURLs       map[string]Storage
-	prioritizeHTTP bool
+	given             Storage
+	httpURLs          map[string]Storage
+	prioritizeHTTP    bool
+	refreshUnknownKID bool
+	refreshLimiter    *rate.Limiter
 }
 
 // NewHTTPClient creates a new JWK Set client from remote HTTP resources.
@@ -51,14 +62,19 @@ func NewHTTPClient(options HTTPClientOptions) (Storage, error) {
 			}
 		}
 	}
+	if options.RefreshUnknownKID && options.RefreshLimiter == nil {
+		return nil, fmt.Errorf("%w: refresh unknown KID is enabled but no refresh limiter is given", ErrNewClient)
+	}
 	given := options.Given
 	if given == nil {
 		given = NewMemoryStorage()
 	}
 	c := httpClient{
-		given:          given,
-		httpURLs:       options.HTTPURLs,
-		prioritizeHTTP: options.PrioritizeHTTP,
+		given:             given,
+		httpURLs:          options.HTTPURLs,
+		prioritizeHTTP:    options.PrioritizeHTTP,
+		refreshUnknownKID: options.RefreshUnknownKID,
+		refreshLimiter:    options.RefreshLimiter,
 	}
 	return c, nil
 }
@@ -66,7 +82,9 @@ func NewHTTPClient(options HTTPClientOptions) (Storage, error) {
 // NewDefaultHTTPClient creates a new JWK Set client with default options from remote HTTP resources.
 func NewDefaultHTTPClient(urls []string) (Storage, error) {
 	clientOptions := HTTPClientOptions{
-		HTTPURLs: make(map[string]Storage),
+		HTTPURLs:          make(map[string]Storage),
+		RefreshUnknownKID: true,
+		RefreshLimiter:    rate.NewLimiter(rate.Every(5*time.Minute), 1),
 	}
 	for _, u := range urls {
 		parsed, err := url.ParseRequestURI(u)
@@ -145,6 +163,34 @@ func (c httpClient) KeyRead(ctx context.Context, keyID string) (jwk JWK, err err
 			return JWK{}, fmt.Errorf("failed to find JWT key with ID %q in given storage due to error: %w", keyID, err)
 		default:
 			return jwk, nil
+		}
+	}
+	if c.refreshUnknownKID {
+		err = c.refreshLimiter.Wait(ctx)
+		if err != nil {
+			return JWK{}, fmt.Errorf("failed to wait for JWK Set refresh rate limiter due to error: %w", err)
+		}
+		for _, store := range c.httpURLs {
+			s, ok := store.(httpStorage)
+			if !ok {
+				continue
+			}
+			err = s.refresh(ctx)
+			if err != nil {
+				if s.options.RefreshErrorHandler != nil {
+					s.options.RefreshErrorHandler(ctx, err)
+				}
+				continue
+			}
+			jwk, err = store.KeyRead(ctx, keyID)
+			switch {
+			case errors.Is(err, ErrKeyNotFound):
+				// Do nothing.
+			case err != nil:
+				return JWK{}, fmt.Errorf("failed to find JWT key with ID %q in HTTP storage due to error: %w", keyID, err)
+			default:
+				return jwk, nil
+			}
 		}
 	}
 	return JWK{}, fmt.Errorf("%w %q", ErrKeyNotFound, keyID)

--- a/http_test.go
+++ b/http_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 )
 
@@ -38,7 +39,10 @@ func TestClient(t *testing.T) {
 		t.Fatalf("Failed to get the JSON.\nError: %s", err)
 	}
 
+	rawJWKSMux := sync.RWMutex{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rawJWKSMux.RLock()
+		defer rawJWKSMux.RUnlock()
 		_, _ = w.Write(rawJWKS)
 	}))
 
@@ -86,12 +90,46 @@ func TestClient(t *testing.T) {
 	if !bytes.Equal(jwk.Key().([]byte), secret) {
 		t.Fatalf("The key read from the HTTP client did not match the original key.")
 	}
+
+	otherKeyID := myKeyID + "2"
+	options.Metadata.KID = otherKeyID
+	otherSecret := []byte("my-other-hmac-secret")
+	jwk, err = NewJWKFromKey(otherSecret, options)
+	if err != nil {
+		t.Fatalf("Failed to create a JWK from the given HMAC secret.\nError: %s", err)
+	}
+
+	err = serverStore.KeyWrite(ctx, jwk)
+	if err != nil {
+		t.Fatalf("Failed to write the given JWK to the store.\nError: %s", err)
+	}
+	rawJWKSMux.Lock()
+	rawJWKS, err = serverStore.JSON(ctx)
+	rawJWKSMux.Unlock()
+	if err != nil {
+		t.Fatalf("Failed to get the JSON.\nError: %s", err)
+	}
+
+	jwk, err = clientStore.KeyRead(ctx, otherKeyID)
+	if err != nil {
+		t.Fatalf("Failed to read the JWK.\nError: %s", err)
+	}
+	if !bytes.Equal(jwk.Key().([]byte), otherSecret) {
+		t.Fatalf("The key read from the HTTP client did not match the original key.")
+	}
 }
 
 func TestClientError(t *testing.T) {
 	_, err := NewHTTPClient(HTTPClientOptions{})
 	if err == nil {
 		t.Fatalf("Expected an error when creating a new HTTP client without any URLs.")
+	}
+	_, err = NewHTTPClient(HTTPClientOptions{
+		HTTPURLs:          map[string]Storage{"http://localhost:8080": NewMemoryStorage()},
+		RefreshUnknownKID: true,
+	})
+	if err == nil {
+		t.Fatalf("Expected an error when creating a new HTTP client with RefreshUnknownKID set to true without rate limiter.")
 	}
 }
 

--- a/storage.go
+++ b/storage.go
@@ -209,6 +209,12 @@ type HTTPClientStorageOptions struct {
 	Storage Storage
 }
 
+type httpStorage struct {
+	options HTTPClientStorageOptions
+	refresh func(ctx context.Context) error
+	Storage
+}
+
 // NewStorageFromHTTP creates a new Storage implementation that processes a remote HTTP resource for a JWK Set. If
 // the RefreshInterval option is not set, the remote HTTP resource will be requested and processed before returning. If
 // the RefreshInterval option is set, a background goroutine will be launched to refresh the remote HTTP resource and
@@ -301,5 +307,11 @@ func NewStorageFromHTTP(u *url.URL, options HTTPClientStorageOptions) (Storage, 
 		return nil, fmt.Errorf("failed to perform first HTTP request for JWK Set: %w", err)
 	}
 
-	return store, nil
+	s := httpStorage{
+		options: options,
+		refresh: refresh,
+		Storage: store,
+	}
+
+	return s, nil
 }


### PR DESCRIPTION
The purpose of this pull request is to add a feature that refreshes remote JWK Set resources when trying to read a key ID `kid` that has not been found in the local cache.

This requires rate limiting and the `pkg.go.dev/golang.org/x/time/rate` has been added as a dependency for that.

This pull request currently changes the default HTTP client. Anyone is invited to comment.