### PR TITLE
fix: multiple public key compatibility, missing metadata

### DIFF
--- a/cmd/jwksetinfer/main.go
+++ b/cmd/jwksetinfer/main.go
@@ -101,7 +101,8 @@ func main() {
 				Private: true,
 			}
 			options := jwkset.JWKOptions{
-				Marshal: marshalOptions,
+				Marshal:  marshalOptions,
+				Metadata: metadata,
 			}
 			jwk, err := jwkset.NewJWKFromKey(key, options)
 			if err != nil {


### PR DESCRIPTION
Using multiple public key pem file input won't generate a JWKS with multiple key.

This PR fix the issue.