### PR TITLE
Required leading zeros in ECDSA keys

### DIFF
--- a/marshal.go
+++ b/marshal.go
@@ -138,7 +138,6 @@ func keyMarshal(key any, options JWKOptions) (JWKMarshal, error) {
 		m.X = bigIntToBase64RawURL(pub.X, l)
 		m.Y = bigIntToBase64RawURL(pub.Y, l)
 		m.KTY = KtyEC
-		println(key.Curve.Params().N.Int64())
 		if options.Marshal.Private {
 			params := key.Curve.Params()
 			f, _ := params.N.Float64()

--- a/marshal_test.go
+++ b/marshal_test.go
@@ -23,9 +23,9 @@ const (
 	ecdsaP384D    = "P0mnrdElxUwAOcYeRlEz6uUNM6v_Bj4iBB4qxfEQ0xpKiAI5wM1lhzyoXibfWRHo"
 	ecdsaP384X    = "qL8wKJLZT5qowOGc8FMYqMWurcdVL15VxHqYV5JmJYj0EjBiPv14iwUrnhEEHVS9"
 	ecdsaP384Y    = "5qSWUmTjYNREUNCjDyAxu-ymHUGOtnEzO2z_pxtl5vd4W5Eb_9QcK9E9z3G3Xxjp"
-	ecdsaP521D    = "Tid_PALr0BgmGglq_pUf-sIWh0-pzLkuL7ohKYmwsFnC8df7ZLQRjGw-66TmyF_FIUcltdoP-3zl2ijOByxX_y0"
-	ecdsaP521X    = "ARxti_MdbyBVgT4N-08XzYBx5c8ZUPtZXshNHu_AoMwQqXq0WjZznL5b2175hv8nsUvRshjHpHaj_7SWQl5vH9f0"
-	ecdsaP521Y    = "AYx5MdFtiuPA1_IVS0A0z8MhLmQNJOxKd1hnhSRlod1sd7sz17WSXz-DggJwK5gj0qFp9_8dsVvI1Yn688myoImU"
+	ecdsaP521D    = "AZQCR6TJTodh-iJtUxLqQsPTJ4y8eob2QYRKAdo_dfYofYkT9XvpSCDZAQzUSxjpxk9Gdgllot_44y14l4Y0eXP0"
+	ecdsaP521X    = "AToMhlpxuo51_edtiBEGla-cRsvxbsDFSKLtOdhqDS9raVEsvGHFvs18Ft-66tFj5qQwuWt0kLxUZ1bK-rccUs5E"
+	ecdsaP521Y    = "ACH57f11RPlibY_THfimCzB_XJIl-dbTr0JPIlqkh3fyJ5qgBn5d7rrvm7skAJZPksLR9pIsQs_0xI2du20l-yz9"
 	eddsaPrivate  = "5hT6NTzNJyUCaG7mqtq2ru0EsA2z5SwnnkP0pBycP64"
 	eddsaPublic   = "VYk14QSFla7FKnL_okf6TqLIyV2X6DPaDi26UpAMVnM"
 	hmacSecret    = "myHMACSecret"
@@ -174,7 +174,7 @@ func TestUnmarshalECDH(t *testing.T) {
 func TestMarshalECDSA(t *testing.T) {
 	keyOps := []KEYOPS{KeyOpsSign, KeyOpsVerify}
 	checkMarshal := func(marshal JWKMarshal, options JWKOptions) {
-		if marshal.ALG != AlgES256 {
+		if marshal.ALG != AlgES512 {
 			t.Fatal(`Marshaled parameter "alg" does not match original key.`)
 		}
 		if marshal.KID != myKeyID {
@@ -186,11 +186,11 @@ func TestMarshalECDSA(t *testing.T) {
 		if marshal.USE != UseSig {
 			t.Fatal(`Marshaled parameter "use" does not match original key.`)
 		}
-		if marshal.CRV != CrvP256 {
+		if marshal.CRV != CrvP521 {
 			t.Fatal(`Marshaled parameter "crv" does not match original key.`)
 		}
 		if options.Marshal.Private {
-			if marshal.D != ecdsaP256D {
+			if marshal.D != ecdsaP521D {
 				t.Fatal(`Marshaled parameter "d" does not match original key.`)
 			}
 		} else {
@@ -201,17 +201,17 @@ func TestMarshalECDSA(t *testing.T) {
 		if marshal.KTY != KtyEC {
 			t.Fatal(`Marshaled parameter "kty" does not match original key.`)
 		}
-		if marshal.X != ecdsaP256X {
+		if marshal.X != ecdsaP521X {
 			t.Fatal(`Marshaled parameter "x" does not match original key.`)
 		}
-		if marshal.Y != ecdsaP256Y {
+		if marshal.Y != ecdsaP521Y {
 			t.Fatal(`Marshaled parameter "y" does not match original key.`)
 		}
 	}
-	private := makeECDSAP256(t)
+	private := makeECDSAP521(t)
 
 	metadata := JWKMetadataOptions{
-		ALG:    AlgES256,
+		ALG:    AlgES512,
 		KID:    myKeyID,
 		KEYOPS: keyOps,
 		USE:    UseSig,


### PR DESCRIPTION
The purpose of this pull request is to add leading zeros to ECDSA key parameters where required to meet the below RFC requirements:

For `"x"` and `"y"`:
> The length of this octet string MUST be the full size of a coordinate for the curve specified in the "crv" parameter.  For example, if the value of "crv" is "P-521", the octet string must be 66 octets long.

For `"d"`:
> The length of this octet string MUST be ceiling(log-base-2(n)/8) octets (where n is the order of the curve).

This is to bring the project into RFC compliance with RFC 7518 Section [6.2.1.2](https://datatracker.ietf.org/doc/html/rfc7518#section-6.2.1.2), [6.2.1.3](https://datatracker.ietf.org/doc/html/rfc7518#section-6.2.1.3), and [6.2.2.1](https://datatracker.ietf.org/doc/html/rfc7518#section-6.2.2.1).

The know effects of this bug are:
1. Producing RFC incompatible JWK parameters when JSON marshaling ECDSA keys where `"x"`, `"y"`, or `"d"` values do not use the same number of octets as the curve's.
2. Failing to process correctly formatted ECDSA keys with this condition due to validation requiring exact matches.