### PR TITLE
Update pgx for website

### DIFF
--- a/website/go.mod
+++ b/website/go.mod
@@ -3,7 +3,7 @@ module github.com/MicahParks/jwkset/website
 go 1.21.5
 
 require (
-	github.com/MicahParks/httphandle v0.5.6
+	github.com/MicahParks/httphandle v0.5.7
 	github.com/MicahParks/jsontype v0.6.1
 	github.com/MicahParks/jwkset v0.5.15
 	github.com/MicahParks/recaptcha v0.0.5
@@ -14,7 +14,7 @@ require (
 	github.com/google/uuid v1.4.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a // indirect
-	github.com/jackc/pgx/v5 v5.5.2 // indirect
+	github.com/jackc/pgx/v5 v5.5.5 // indirect
 	golang.org/x/crypto v0.17.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	golang.org/x/time v0.5.0 // indirect

--- a/website/go.sum
+++ b/website/go.sum
@@ -1,5 +1,7 @@
 github.com/MicahParks/httphandle v0.5.6 h1:C3wbRA45XfVcT+E1n9z52ZXqYjnLKeg+uIwsFozcc9U=
 github.com/MicahParks/httphandle v0.5.6/go.mod h1:b1/C8KRzVj9RumQosDxQJHoU0vwKoicQXfxe8p6B2Bg=
+github.com/MicahParks/httphandle v0.5.7 h1:v0T8g9DzMCuWBdSUtbz0ptrxv6Wu+P+BuhblfE9XIm0=
+github.com/MicahParks/httphandle v0.5.7/go.mod h1:TsKDADgU5TG9PnfgtXMo643eMOUifg0nGiZzDG3fiKQ=
 github.com/MicahParks/jsontype v0.6.1 h1:yFiDEOgSCDT+Es8k17PYZkvpqbZJ9GxJH2ioeVGvgt0=
 github.com/MicahParks/jsontype v0.6.1/go.mod h1:PVeg4g8eHt4QDlhe56X1sWzRuHiVlCg4m0vgkpEso/Y=
 github.com/MicahParks/jwkset v0.5.15 h1:ACJY045Zuvo2TVWikeFLnKTIsEDQQHUHrNYiMW+gj24=
@@ -19,6 +21,8 @@ github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a h1:bbPeKD0xmW/
 github.com/jackc/pgservicefile v0.0.0-20221227161230-091c0ba34f0a/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
 github.com/jackc/pgx/v5 v5.5.2 h1:iLlpgp4Cp/gC9Xuscl7lFL1PhhW+ZLtXZcrfCt4C3tA=
 github.com/jackc/pgx/v5 v5.5.2/go.mod h1:ez9gk+OAat140fv9ErkZDYFWmXLfV+++K0uAOiwgm1A=
+github.com/jackc/pgx/v5 v5.5.5 h1:amBjrZVmksIdNjxGW/IiIMzxMKZFelXbUoPNb+8sjQw=
+github.com/jackc/pgx/v5 v5.5.5/go.mod h1:ez9gk+OAat140fv9ErkZDYFWmXLfV+++K0uAOiwgm1A=
 github.com/jackc/puddle/v2 v2.2.1 h1:RhxXJtFG022u4ibrCSMSiu5aOq1i77R3OHKNJj77OAk=
 github.com/jackc/puddle/v2 v2.2.1/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
The website doesn't actually use `pgx`, but a dependency `github.com/MicahParks/httphandle` does.