### PR TITLE
Add with-option style functions to override client/storage defaults

### DIFF
--- a/options.go
+++ b/options.go
@@ -1,0 +1,105 @@
+package jwkset
+
+import (
+	"context"
+	"golang.org/x/time/rate"
+	"net/http"
+	"time"
+)
+
+// HTTPClientOption wraps HTTPClientOptions to override defaults.
+type HTTPClientOption func(*HTTPClientOptions)
+
+// HTTPClientStorageOption wraps HTTPClientStorageOptions to override defaults.
+type HTTPClientStorageOption func(*HTTPClientStorageOptions)
+
+// WithGiven overrides default HTTPClientOptions.Given option.
+func WithGiven(given Storage) HTTPClientOption {
+	return func(options *HTTPClientOptions) {
+		options.Given = given
+	}
+}
+
+// WithPrioritizeHTTP overrides default HTTPClientOptions.PrioritizeHTTP option.
+func WithPrioritizeHTTP(prioritize bool) HTTPClientOption {
+	return func(o *HTTPClientOptions) {
+		o.PrioritizeHTTP = prioritize
+	}
+}
+
+// WithRateLimitWaitMax overrides default HTTPClientOptions.RateLimitWaitMax option.
+func WithRateLimitWaitMax(waitMax time.Duration) HTTPClientOption {
+	return func(o *HTTPClientOptions) {
+		o.RateLimitWaitMax = waitMax
+	}
+}
+
+// WithRefreshUnknownKID overrides default HTTPClientOptions.RefreshUnknownKID option.
+func WithRefreshUnknownKID(limiter *rate.Limiter) HTTPClientOption {
+	return func(o *HTTPClientOptions) {
+		o.RefreshUnknownKID = limiter
+	}
+}
+
+// WithStorageOptions sets HTTPClientStorageOption(s) to override default HTTPClientStorageOptions.
+func WithStorageOptions(storageOptions ...HTTPClientStorageOption) HTTPClientOption {
+	return func(o *HTTPClientOptions) {
+		o.storageOptions = storageOptions
+	}
+}
+
+// WithClient overrides default HTTPClientStorageOptions.Client option.
+func WithClient(client *http.Client) HTTPClientStorageOption {
+	return func(o *HTTPClientStorageOptions) {
+		o.Client = client
+	}
+}
+
+// WithHTTPExpectedStatus overrides default HTTPClientStorageOptions.HTTPExpectedStatus option.
+func WithHTTPExpectedStatus(status int) HTTPClientStorageOption {
+	return func(o *HTTPClientStorageOptions) {
+		o.HTTPExpectedStatus = status
+	}
+}
+
+// WithHTTPMethod overrides default HTTPClientStorageOptions.HTTPMethod option.
+func WithHTTPMethod(method string) HTTPClientStorageOption {
+	return func(o *HTTPClientStorageOptions) {
+		o.HTTPMethod = method
+	}
+}
+
+// WithHTTPTimeout overrides default HTTPClientStorageOptions.HTTPTimeout option.
+func WithHTTPTimeout(timeout time.Duration) HTTPClientStorageOption {
+	return func(o *HTTPClientStorageOptions) {
+		o.HTTPTimeout = timeout
+	}
+}
+
+// WithNoErrorReturnFirstHTTPReq overrides default HTTPClientStorageOptions.NoErrorReturnFirstHTTPReq option.
+func WithNoErrorReturnFirstHTTPReq(noError bool) HTTPClientStorageOption {
+	return func(o *HTTPClientStorageOptions) {
+		o.NoErrorReturnFirstHTTPReq = noError
+	}
+}
+
+// WithRefreshErrorHandler overrides default HTTPClientStorageOptions.RefreshErrorHandler option.
+func WithRefreshErrorHandler(handler func(ctx context.Context, err error)) HTTPClientStorageOption {
+	return func(o *HTTPClientStorageOptions) {
+		o.RefreshErrorHandler = handler
+	}
+}
+
+// WithRefreshInterval overrides default HTTPClientStorageOptions.RefreshInterval option.
+func WithRefreshInterval(interval time.Duration) HTTPClientStorageOption {
+	return func(o *HTTPClientStorageOptions) {
+		o.RefreshInterval = interval
+	}
+}
+
+// WithStorage overrides default HTTPClientStorageOptions.Storage option.
+func WithStorage(storage Storage) HTTPClientStorageOption {
+	return func(o *HTTPClientStorageOptions) {
+		o.Storage = storage
+	}
+}

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,155 @@
+package jwkset
+
+import (
+	"context"
+	"golang.org/x/time/rate"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+func TestWithClientOptions(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  HTTPClientOptions
+		opt  HTTPClientOption
+		want HTTPClientOptions
+	}{
+		{
+			"WithGiven",
+			HTTPClientOptions{},
+			WithGiven(NewMemoryStorage()),
+			HTTPClientOptions{Given: NewMemoryStorage()},
+		},
+		{
+			"WithPrioritizeHTTP",
+			HTTPClientOptions{},
+			WithPrioritizeHTTP(true),
+			HTTPClientOptions{PrioritizeHTTP: true},
+		},
+		{
+			"WithRateLimitWaitMax",
+			HTTPClientOptions{},
+			WithRateLimitWaitMax(42),
+			HTTPClientOptions{RateLimitWaitMax: 42},
+		},
+		{
+			"WithRefreshUnknownKID",
+			HTTPClientOptions{},
+			WithRefreshUnknownKID(rate.NewLimiter(4, 2)),
+			HTTPClientOptions{RefreshUnknownKID: rate.NewLimiter(4, 2)},
+		},
+		{
+			"WithStorageOptions",
+			HTTPClientOptions{},
+			WithRefreshUnknownKID(rate.NewLimiter(4, 2)),
+			HTTPClientOptions{RefreshUnknownKID: rate.NewLimiter(4, 2)},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.opt(&tt.arg)
+			if !reflect.DeepEqual(tt.arg, tt.want) {
+				t.Errorf("%s() = %v, want %v", tt.name, tt.arg, tt.want)
+			}
+		})
+	}
+}
+
+func TestWithClientStorageOptions(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  HTTPClientStorageOptions
+		opt  HTTPClientStorageOption
+		want HTTPClientStorageOptions
+	}{
+		{
+			"WithClient",
+			HTTPClientStorageOptions{},
+			WithClient(http.DefaultClient),
+			HTTPClientStorageOptions{Client: http.DefaultClient},
+		},
+		{
+			"WithHTTPExpectedStatus",
+			HTTPClientStorageOptions{},
+			WithHTTPExpectedStatus(http.StatusTeapot),
+			HTTPClientStorageOptions{HTTPExpectedStatus: http.StatusTeapot},
+		},
+		{
+			"WithHTTPMethod",
+			HTTPClientStorageOptions{},
+			WithHTTPMethod(http.MethodOptions),
+			HTTPClientStorageOptions{HTTPMethod: http.MethodOptions},
+		},
+		{
+			"WithHTTPTimeout",
+			HTTPClientStorageOptions{},
+			WithHTTPTimeout(42),
+			HTTPClientStorageOptions{HTTPTimeout: 42},
+		},
+		{
+			"WithNoErrorReturnFirstHTTPReq",
+			HTTPClientStorageOptions{},
+			WithNoErrorReturnFirstHTTPReq(true),
+			HTTPClientStorageOptions{NoErrorReturnFirstHTTPReq: true},
+		},
+		{
+			"WithRefreshErrorHandler",
+			HTTPClientStorageOptions{RefreshErrorHandler: func(_ context.Context, _ error) {}},
+			WithRefreshErrorHandler(nil),
+			HTTPClientStorageOptions{RefreshErrorHandler: nil},
+		},
+		{
+			"WithRefreshInterval",
+			HTTPClientStorageOptions{},
+			WithRefreshInterval(42),
+			HTTPClientStorageOptions{RefreshInterval: 42},
+		},
+		{
+			"WithStorage",
+			HTTPClientStorageOptions{},
+			WithStorage(NewMemoryStorage()),
+			HTTPClientStorageOptions{Storage: NewMemoryStorage()},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.opt(&tt.arg)
+			if !reflect.DeepEqual(tt.arg, tt.want) {
+				t.Errorf("%s() = %v, want %v", tt.name, tt.arg, tt.want)
+			}
+		})
+	}
+}
+
+func TestWithStorageOptions(t *testing.T) {
+	name := "WithStorageOptions"
+	arg1 := HTTPClientOptions{}
+	arg2 := HTTPClientStorageOptions{}
+	opt := WithStorageOptions(
+		WithClient(http.DefaultClient),
+		WithHTTPExpectedStatus(http.StatusTeapot),
+		WithHTTPMethod(http.MethodOptions),
+		WithHTTPTimeout(42),
+		WithNoErrorReturnFirstHTTPReq(true),
+		WithRefreshInterval(42),
+		WithStorage(NewMemoryStorage()))
+	want := HTTPClientStorageOptions{
+		Client:                    http.DefaultClient,
+		HTTPExpectedStatus:        http.StatusTeapot,
+		HTTPMethod:                http.MethodOptions,
+		HTTPTimeout:               42,
+		NoErrorReturnFirstHTTPReq: true,
+		RefreshInterval:           42,
+		Storage:                   NewMemoryStorage(),
+	}
+	t.Run(name, func(t *testing.T) {
+		opt(&arg1)
+		for _, sopt := range arg1.storageOptions {
+			sopt(&arg2)
+		}
+		if !reflect.DeepEqual(arg2, want) {
+			t.Errorf("%s() = %v, want %v", name, arg2, want)
+		}
+	})
+}


### PR DESCRIPTION
The purpose of the PR is to add the ability to override the default HTTP client options and HTTP client storage options instead of building them from scratch in client code.

Example:
```
client, _ := jwkset.NewDefaultHTTPClientCtx(
	ctx, urls,
	jwkset.WithPrioritizeHTTP(true),
	jwkset.WithStorageOptions(
		jwkset.WithRefreshInterval(time.Minute),
		jwkset.WithRefreshErrorHandler(...))),
options := keyfunc.Options{
	Storage: client,
}
keyfunc.New(options)
```