### PR TITLE
fix return of httpStorage in NewStorageFromHTTP

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -295,6 +295,12 @@ func NewStorageFromHTTP(u *url.URL, options HTTPClientStorageOptions) (Storage, 
 		}()
 	}
 
+	s := httpStorage{
+		options: options,
+		refresh: refresh,
+		Storage: store,
+	}
+
 	ctx, cancel := context.WithTimeout(options.Ctx, options.HTTPTimeout)
 	defer cancel()
 	err := refresh(ctx)
@@ -304,15 +310,9 @@ func NewStorageFromHTTP(u *url.URL, options HTTPClientStorageOptions) (Storage, 
 			if options.RefreshErrorHandler != nil {
 				options.RefreshErrorHandler(ctx, err)
 			}
-			return store, nil
+			return s, nil
 		}
 		return nil, fmt.Errorf("failed to perform first HTTP request for JWK Set: %w", err)
-	}
-
-	s := httpStorage{
-		options: options,
-		refresh: refresh,
-		Storage: store,
 	}
 
 	return s, nil


### PR DESCRIPTION
`NewStorageFromHTTP` returns the underlying store instead of httpStorage when `NoErrorReturnFirstHTTPReq` is set.

This results in type assertion checks to fail when using in combination with `NewHTTPClient` configured with `RefreshUnknownKID`.