### PR TITLE
Makes the final image more secure

### DIFF
--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -3,7 +3,8 @@ WORKDIR /app
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags "-s -w" -o jwksetcom -trimpath cmd/server/*.go
 
-FROM alpine
+FROM scratch
 COPY --from=builder /app/jwksetcom /jwksetcom
+USER 10001
 ENV CONFIG_JSON='{}'
 CMD ["/jwksetcom"]


### PR DESCRIPTION
- Added scratch as a base for final image, since scratch contains less binaries and so, less vulnerabilities. And it's smaller also.
- Changed from root user to user ID 10001 to be able to run container as non-root