### PR TITLE
Improve certificate thumbprint check

### DIFF
--- a/jwk.go
+++ b/jwk.go
@@ -317,10 +317,11 @@ func (j JWK) Validate() error {
 		marshalled.X5TS256 = ""
 	}
 
-	if j.marshal.X5T != marshalled.X5T {
+	canComputeThumbprint := len(j.marshal.X5C) > 0
+	if j.marshal.X5T != marshalled.X5T && canComputeThumbprint {
 		return fmt.Errorf("%w: X5T in marshal does not match X5T in marshalled", ErrJWKValidation)
 	}
-	if j.marshal.X5TS256 != marshalled.X5TS256 {
+	if j.marshal.X5TS256 != marshalled.X5TS256 && canComputeThumbprint {
 		return fmt.Errorf("%w: X5TS256 in marshal does not match X5TS256 in marshalled", ErrJWKValidation)
 	}
 	if j.marshal.CRV != marshalled.CRV {


### PR DESCRIPTION
[RFC 7517](https://datatracker.ietf.org/doc/html/rfc7517#section-4.8) seems to allow certificate thumbprints to be present in a JWK Set, such as `x5t`, even if no certificate members are present, such as `x5c`.

This PR allows JWK to validate in this scenario.

Originally brought up in this issue: https://github.com/MicahParks/keyfunc/issues/128