### PR TITLE
Expose ValidateOptions in HTTPClientStorageOptions

### DIFF
--- a/storage.go
+++ b/storage.go
@@ -207,6 +207,9 @@ type HTTPClientStorageOptions struct {
 	//
 	// This defaults to NewMemoryStorage().
 	Storage Storage
+
+	// ValidateOptions are the options to use when validating the JWKs.
+	ValidateOptions JWKValidateOptions
 }
 
 type httpStorage struct {
@@ -263,7 +266,7 @@ func NewStorageFromHTTP(u *url.URL, options HTTPClientStorageOptions) (Storage, 
 			marshalOptions := JWKMarshalOptions{
 				Private: true,
 			}
-			jwk, err := NewJWKFromMarshal(marshal, marshalOptions, JWKValidateOptions{})
+			jwk, err := NewJWKFromMarshal(marshal, marshalOptions, options.ValidateOptions)
 			if err != nil {
 				return fmt.Errorf("failed to create JWK from JWK Marshal: %w", err)
 			}


### PR DESCRIPTION
Adds the ability to configure the JWK validation options when using the HTTP storage.

This API is necessary (I think?) for https://github.com/MicahParks/keyfunc/issues/126 but I guess is also quite useful otherwise.