### PR TITLE
Properly replace JWK during refresh

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/MicahParks/jwkset
 go 1.21
 
 require golang.org/x/time v0.5.0
+
+retract [v0.5.0, v0.5.15] // HTTP client failed to remove JWK from set if not in refresh: https://github.com/MicahParks/jwkset/issues/40


### PR DESCRIPTION
The purpose of this pull request is to close #40. 

> The local JWK Set cache should do a full replacement of JWK when the goroutine refreshes the remote JWK Set. The current behavior is an append. This is a security issue for use cases where key removal from a JWK Set is equivalent to revocation.
>
> Regardless of this bug, please note that removing a key from a JWK Set does not equate to instant revocation for most use cases as it takes time for JWK Set updates to propagate to all clients.