### PR TITLE
Tolerate non-canonical base64url padding for OKP keys

### DIFF
--- a/jwk.go
+++ b/jwk.go
@@ -342,11 +342,13 @@ func (j JWK) Validate() error {
 			return fmt.Errorf("%w: D in marshal does not match D in marshalled", errors.Join(ErrJWKValidation, err))
 		}
 	case KtyOKP:
-		if j.marshal.X != marshalled.X {
-			return fmt.Errorf("%w: X in marshal does not match X in marshalled", ErrJWKValidation)
+		err = cmpBase64Octet(j.marshal.X, marshalled.X, j.options.Validate.StrictPadding)
+		if err != nil {
+			return fmt.Errorf("%w: X in marshal does not match X in marshalled", errors.Join(ErrJWKValidation, err))
 		}
-		if j.marshal.D != marshalled.D {
-			return fmt.Errorf("%w: D in marshal does not match D in marshalled", ErrJWKValidation)
+		err = cmpBase64Octet(j.marshal.D, marshalled.D, j.options.Validate.StrictPadding)
+		if err != nil {
+			return fmt.Errorf("%w: D in marshal does not match D in marshalled", errors.Join(ErrJWKValidation, err))
 		}
 	case KtyRSA:
 		err = cmpBase64Int(j.marshal.D, marshalled.D, j.options.Validate.StrictPadding)
@@ -505,6 +507,37 @@ func cmpBase64Int(first, second string, strictPadding bool) error {
 	}
 	if strictPadding && fLen != sLen {
 		return fmt.Errorf("%w: the Base64 raw URL inputs do not have matching padding", errors.Join(ErrJWKValidation, ErrPadding))
+	}
+	return nil
+}
+
+func cmpBase64Octet(first, second string, strictPadding bool) error {
+	if first == second {
+		return nil
+	}
+	var f, s []byte
+	var err error
+	if strictPadding {
+		f, err = base64.RawURLEncoding.DecodeString(first)
+		if err != nil {
+			return fmt.Errorf("failed to decode Base64 raw URL decode first string: %w", err)
+		}
+		s, err = base64.RawURLEncoding.DecodeString(second)
+		if err != nil {
+			return fmt.Errorf("failed to decode Base64 raw URL decode second string: %w", err)
+		}
+	} else {
+		f, err = base64urlTrailingPadding(first)
+		if err != nil {
+			return fmt.Errorf("failed to decode Base64 URL (remove trailing padding) decode first string: %w", err)
+		}
+		s, err = base64urlTrailingPadding(second)
+		if err != nil {
+			return fmt.Errorf("failed to decode Base64 URL (remove trailing padding) decode second string: %w", err)
+		}
+	}
+	if !bytes.Equal(f, s) {
+		return fmt.Errorf("%w: the parsed octets do not match", ErrJWKValidation)
 	}
 	return nil
 }

--- a/jwk_test.go
+++ b/jwk_test.go
@@ -262,6 +262,28 @@ func TestJWK_Validate_Padding(t *testing.T) {
 	}
 }
 
+func TestJWK_Validate_Padding_OKP(t *testing.T) {
+	const invalidOKPPadding = `
+{
+  "kty": "OKP",
+  "crv": "Ed25519",
+  "x": "8vD0Rexp6F8V6JbRvp3KXa5mJeVd9IrGh9fwwhgInfk="
+}`
+	jwk, err := NewJWKFromRawJSON([]byte(invalidOKPPadding), JWKMarshalOptions{}, JWKValidateOptions{})
+	if err != nil {
+		t.Fatalf("Failed to create JWK from raw JSON. %s", err)
+	}
+	err = jwk.Validate()
+	if err != nil {
+		t.Fatalf("Failed to validate OKP JWK with acceptably invalid padding. %s", err)
+	}
+	jwk.options.Validate.StrictPadding = true
+	err = jwk.Validate()
+	if err == nil {
+		t.Fatalf("Expected to fail validation for invalid OKP padding.")
+	}
+}
+
 func TestCmpBase64Int(t *testing.T) {
 	intA := int64(123_456_789)
 	bytesA := big.NewInt(intA).Bytes()


### PR DESCRIPTION
I noticed `Validate` compares the OKP `x` and `d` parameters as raw strings, while
RSA and EC go through `cmpBase64Int`. Because of that, an OKP key whose base64url
value has trailing padding gets rejected during validation, even though
`keyUnmarshal` decodes it without complaint. So the "acceptably invalid padding"
behavior that `TestJWK_Validate_Padding` already covers for RSA and EC never
actually applied to OKP keys.

This adds `cmpBase64Octet`, which works like `cmpBase64Int` but compares the
decoded bytes instead of the integer value. I used a byte comparison because OKP
keys are fixed length octet strings, where leading zeros are significant and would
get dropped by a `big.Int`. The OKP case now uses it for both `x` and `d`, and
`StrictPadding` still rejects paddedd input like before. I also added
`TestJWK_Validate_Padding_OKP` next to the existing padding test