### PR TITLE
Add ALG.Prohibited() to report prohibited algorithms

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -101,6 +101,13 @@ func (alg ALG) IANARegistered() bool {
 	}
 	return false
 }
+func (alg ALG) Prohibited() bool {
+	switch alg {
+	case AlgRS1, AlgHS1, AlgA128CBC, AlgA192CBC, AlgA256CBC, AlgA128CTR, AlgA192CTR, AlgA256CTR:
+		return true
+	}
+	return false
+}
 func (alg ALG) String() string {
 	return string(alg)
 }

--- a/constants_test.go
+++ b/constants_test.go
@@ -16,9 +16,16 @@ func TestALG(t *testing.T) {
 	if !a.IANARegistered() {
 		t.Errorf("Failed to validate valid ALG.")
 	}
+	if a.Prohibited() {
+		t.Errorf("Non-prohibited ALG reported as prohibited.")
+	}
 	a = invalid
 	if a.IANARegistered() {
 		t.Errorf("Do not validate invalid ALG.")
+	}
+	a = AlgHS1
+	if !a.Prohibited() {
+		t.Errorf("Prohibited ALG not reported as prohibited.")
 	}
 }
 


### PR DESCRIPTION
constants.go already marks eight algorithm identifiers as prohibited in comments (RS1, HS1 and the unauthenticated A128CBC/A192CBC/A256CBC and A128CTR/A192CTR/A256CTR), but there is no way to check that at runtime. IANARegistered returns true for them, which makes sense since they are recognized identifiers, so a caller that wants to reject the weak ones currently has to hardcode the list itself.

This adds ALG.Prohibited() next to IANARegistered(), returning true for exactly those eight. The idea is that a security conscious caller can do something like if alg.Prohibited() { reject } when validating a JWK, without duplicating the list or letting it drift out of sync with the comments here. RS1 and HS1 rely on SHA-1, and the bare CBC and CTR modes are unauthenticated, so rejecting them is a reasonable default for a lot of setups.

I kept this to just the method plus a test. If you are interested, I am happy to follow up in a separate PR with an opt in validate option (rejecting prohibited algorithms during Validate), but I did not want to change validation behavior without checking first